### PR TITLE
Tag both Channel ID and Channel for Upstream Bonded Channels

### DIFF
--- a/scrape/downstreambondedchannel.go
+++ b/scrape/downstreambondedchannel.go
@@ -33,7 +33,6 @@ func (d DownstreamBondedChannel) ToInfluxPoints() ([]*client.Point, error) {
 		"channel_id": channelIDString,
 	}
 	fields := map[string]interface{}{
-		// "channel_id":     d.ChannelID,
 		"lock_status":    d.LockStatus,
 		"modulation":     d.Modulation,
 		"frequency_hz":   d.FrequencyHz,

--- a/scrape/upstreambondedchannel.go
+++ b/scrape/upstreambondedchannel.go
@@ -29,12 +29,12 @@ func (u UpstreamBondedChannel) ToInfluxPoints() ([]*client.Point, error) {
 	var points []*client.Point
 
 	channelString := strconv.Itoa(u.Channel)
+	channelIDString := strconv.Itoa(u.ChannelID)
 	tags := map[string]string{
-		"channel": channelString,
+		"channel":    channelString,
+		"channel_id": channelIDString,
 	}
 	fields := map[string]interface{}{
-		// "channel":         u.Channel,
-		"channel_id":      u.ChannelID,
 		"lock_status":     u.LockStatus,
 		"us_channel_type": u.USChannelType,
 		"frequency_hz":    u.FrequencyHz,


### PR DESCRIPTION
What are your thoughts on this? I had a hard time pulling formal definitions for these channels, but my gut feeling was that both Channel and Channel ID would qualify as tags rather than fields for Upstream Bonded Channels.

Before:

```
> show tag keys from upstream_bonded_channel
name: upstream_bonded_channel
tagKey                                                                                                                            
------                                                                                                                            
channel                                                                                                                           
> show field keys from upstream_bonded_channel
name: upstream_bonded_channel
fieldKey        fieldType                                                                                                         
--------        ---------                                                                                                         
channel_id      integer                                                                                                           
frequency_hz    integer                                                                                                           
lock_status     string                                                                                                            
power_dbmv      float                                                                                                             
us_channel_type string
width_hz        integer
```

After:

```
> show tag keys from upstream_bonded_channel
name: upstream_bonded_channel
tagKey
------
channel
channel_id
> show field keys from upstream_bonded_channel
name: upstream_bonded_channel
fieldKey        fieldType
--------        ---------
frequency_hz    integer
lock_status     string
power_dbmv      float
us_channel_type string
width_hz        integer
```

```
> select * from upstream_bonded_channel limit 4
name: upstream_bonded_channel
time                channel channel_id frequency_hz lock_status power_dbmv us_channel_type width_hz                               
----                ------- ---------- ------------ ----------- ---------- --------------- --------                               
1588550735000000000 1       6          29600000     Locked      44         SC-QAM Upstream 6400000                                
1588550735000000000 2       5          36100000     Locked      44         SC-QAM Upstream 6400000                                
1588550735000000000 3       7          23000000     Locked      44         SC-QAM Upstream 6400000                                
1588550735000000000 4       8          16500000     Locked      44         SC-QAM Upstream 6400000  
```

```
$ scripts/test.sh                                                    
?       github.com/pdunnavant/modem-scraper     [no test files]
?       github.com/pdunnavant/modem-scraper/config      [no test files]                                                           
?       github.com/pdunnavant/modem-scraper/influxdb    [no test files]                                                           
?       github.com/pdunnavant/modem-scraper/mqtt        [no test files]                                                           
ok      github.com/pdunnavant/modem-scraper/scrape      1.033s  coverage: 33.8% of statements          
```